### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Android URL Mp3 Media Player [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-URLMediaPlayer-brightgreen.svg?style=flat)](http://android-arsenal.com/details/3/1765)
 Give an mp3 URL and an image URL to Media Player Activity and it will render a nice player for you!
 
-##Usage
+## Usage
 Copy and paste URLMediaPlayerActivity.java into your code and pass the URLs to it using an intent.
 
 ![alt tag](https://raw.githubusercontent.com/avafab/URLMediaPlayer/master/screenshots/device-2015-02-28-223128.png)
 
-##Developed By
+## Developed By
 
 * Fabrizio Avantaggiato - http://avafab.com - <avafab@gmail.com>
 
-##License
+## License
 ```
 Copyright 2015 Fabrizio Avantaggiato
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
